### PR TITLE
Bump + Allow to replace component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fractalide"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Denis Michiels <dmichiels@gmail.com>"]
 license = "AGPL-3.0"
 homepage = "http://github.com/fractalide/fractalide"

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -49,7 +49,7 @@ pub struct Scheduler {
     /// Will be private, public for debug
     pub components: HashMap<String, Comp>,
     pub subnets: HashMap<String, SubNet>,
-    sender: Sender<CompMsg>,
+    pub sender: Sender<CompMsg>,
     th: JoinHandle<()>,
 }
 


### PR DESCRIPTION
## general
This is the end of the "disconnect + remove + replace" part of the RustFBP, so I bump the version.
You can see an example in the test. A component is swapped, but there is no influence on the other components of the graph.

## Allow to replace
The component offers methods that allows to retrieve all information to
swap the component while running.
It's not possible to change the name of the component.
